### PR TITLE
Work around compilation issues with libc 2.5

### DIFF
--- a/src/shl_pty.c
+++ b/src/shl_pty.c
@@ -574,10 +574,10 @@ int shl_pty_signal(struct shl_pty *pty, int sig)
 		return -ENODEV;
 #ifdef TIOCSIG
 	r = ioctl(pty->fd, TIOCSIG, sig);
-#else
-  r = 0;
-#endif
 	return (r < 0) ? -errno : 0;
+#else
+	return -ENOSYS;
+#endif
 }
 
 int shl_pty_resize(struct shl_pty *pty,


### PR DESCRIPTION
```
libshl/src/shl_pty.c: In function ‘pty_init_child’:
libshl/src/shl_pty.c:356: error: ‘O_CLOEXEC’ undeclared (first use in this function)
libshl/src/shl_pty.c:356: error: (Each undeclared identifier is reported only once
libshl/src/shl_pty.c:356: error: for each function it appears in.)
libshl/src/shl_pty.c: In function ‘shl_pty_open’:
libshl/src/shl_pty.c:392: error: ‘O_CLOEXEC’ undeclared (first use in this function)
libshl/src/shl_pty.c:398: warning: implicit declaration of function ‘pipe2’
libshl/src/shl_pty.c: In function ‘shl_pty_signal’:
libshl/src/shl_pty.c:566: error: ‘TIOCSIG’ undeclared (first use in this function)
libshl/src/shl_pty.c: In function ‘shl_pty_bridge_new’:
libshl/src/shl_pty.c:606: warning: implicit declaration of function ‘epoll_create1’
libshl/src/shl_pty.c:606: error: ‘EPOLL_CLOEXEC’ undeclared (first use in this function)

$ ldd --version
ldd (GNU libc) 2.5
Copyright (C) 2006 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
```
